### PR TITLE
移动methods循序到最后一个

### DIFF
--- a/Vue-Style-Guide.md
+++ b/Vue-Style-Guide.md
@@ -12,10 +12,10 @@ export default {
   route,
   created，
   ready，    // => 生命周期顺序不赘述
-  methods,
   event,
   watch,
-  components
+  components,
+  methods
 }
 ```
 


### PR DESCRIPTION
我觉得methods会是代码最多的一个地方，写在最后比较好定位，也不影响前面那些属性的阅读
